### PR TITLE
Fix incomplete README installation instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,77 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo tests
+        run: cargo test --all-features
+
+      - name: Run cargo clippy
+        run: cargo clippy --all-features -- -D warnings
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build wheels
+        run: maturin build --release --strip
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: target/wheels/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build sdist
+        run: maturin sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: target/wheels/*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,119 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build wheels
+        run: maturin build --release --strip
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: target/wheels/*.whl
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build sdist
+        run: maturin sdist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: target/wheels/*.tar.gz
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-wheels, build-sdist]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p wheels
+          find dist -name '*.whl' -exec cp {} wheels/ \;
+          find dist -name '*.tar.gz' -exec cp {} wheels/ \;
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: wheels/*
+          generate_release_notes: true
+          draft: false
+          prerelease: false
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    needs: [build-wheels, build-sdist, create-release]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && github.event_name == 'push'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/ty-find
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Flatten artifacts
+        run: |
+          mkdir -p wheels
+          find dist -name '*.whl' -exec cp {} wheels/ \;
+          find dist -name '*.tar.gz' -exec cp {} wheels/ \;
+          ls -la wheels/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: wheels/
+          skip-existing: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ A blazingly fast command-line tool for Python code navigation using ty's LSP ser
 
 ### Prerequisites
 - [ty](https://github.com/astral-sh/ty) type checker: `pip install ty`
-- Rust toolchain (for building from source)
+
+### Quick Install (Recommended)
+
+Pre-built wheels are available for Linux, macOS, and Windows:
+
+```bash
+# Install from PyPI (coming soon - once first release is published)
+pip install ty-find
+
+# Or with uv
+uv pip install ty-find
+```
 
 ### For Python Projects
 
@@ -25,29 +36,32 @@ Add to your `pyproject.toml`:
 # For pip/setuptools projects
 [project.optional-dependencies]
 dev = [
-    "ty-find @ git+https://github.com/mojzis/ty-find.git",
+    "ty-find",  # Once published to PyPI
 ]
 
 # For uv projects (recommended)
 [dependency-groups]
 dev = [
-    "ty-find @ git+https://github.com/mojzis/ty-find.git",
+    "ty-find",
 ]
 ```
 
-Then install:
+### Install from Git (Pre-Release)
+
+Until the first PyPI release, install from Git:
+
 ```bash
-# With uv (recommended - will automatically build Rust binary)
-uv sync --group dev
-
-# Or with pip
-pip install -e ".[dev]"
-
-# Or install ty-find directly
+# Requires Rust toolchain to build from source
 pip install "ty-find @ git+https://github.com/mojzis/ty-find.git"
+
+# Or with uv
+uv pip install "ty-find @ git+https://github.com/mojzis/ty-find.git"
 ```
 
-### From Source (Rust)
+**Note:** Installing from Git requires the Rust toolchain. Pre-built wheels eliminate this requirement.
+
+### From Source (Development)
+
 ```bash
 git clone https://github.com/mojzis/ty-find.git
 cd ty-find

--- a/docs/publishing-to-pypi.md
+++ b/docs/publishing-to-pypi.md
@@ -1,0 +1,158 @@
+# Publishing to PyPI
+
+This document explains how to publish ty-find to PyPI using the automated CI/CD workflows.
+
+## Setup (One-Time)
+
+### 1. Set up PyPI Trusted Publishing
+
+Trusted Publishing is the modern, secure way to publish to PyPI without storing tokens.
+
+1. Go to https://pypi.org and create an account (if you don't have one)
+2. Create a "pending publisher" for your package:
+   - Go to https://pypi.org/manage/account/publishing/
+   - Click "Add a new pending publisher"
+   - Fill in:
+     - **PyPI Project Name:** `ty-find`
+     - **Owner:** `mojzis` (your GitHub username)
+     - **Repository name:** `ty-find`
+     - **Workflow name:** `release.yml`
+     - **Environment name:** `pypi`
+3. Click "Add"
+
+**Note:** After your first successful release, this will become a permanent publisher configuration.
+
+### 2. Verify GitHub Actions are enabled
+
+- Go to your repository settings → Actions → General
+- Ensure "Allow all actions and reusable workflows" is selected
+- Save if you made changes
+
+## Publishing a Release
+
+### Option 1: Automated Release (Recommended)
+
+1. **Update version** in `Cargo.toml`:
+   ```toml
+   [package]
+   version = "0.1.0"  # Bump this version
+   ```
+
+2. **Create and push a git tag**:
+   ```bash
+   git tag v0.1.0
+   git push origin v0.1.0
+   ```
+
+3. **The workflow will automatically:**
+   - ✅ Build wheels for Linux, macOS (Intel & Apple Silicon), and Windows
+   - ✅ Build source distribution (sdist)
+   - ✅ Create a GitHub Release with all artifacts
+   - ✅ Publish to PyPI (if trusted publishing is set up)
+
+4. **Monitor the workflow:**
+   - Go to the "Actions" tab in your GitHub repository
+   - Watch the "Release" workflow run
+   - Check for any errors
+
+5. **Verify publication:**
+   - Check https://pypi.org/project/ty-find/
+   - Try installing: `pip install ty-find`
+
+### Option 2: Manual Trigger
+
+You can also manually trigger a release build without creating a tag:
+
+1. Go to Actions → Release workflow
+2. Click "Run workflow"
+3. Select the branch
+4. Click "Run workflow"
+
+This will build wheels but won't create a GitHub Release or publish to PyPI.
+
+## Versioning Scheme
+
+Follow semantic versioning (semver):
+- **MAJOR** version for incompatible API changes
+- **MINOR** version for new functionality (backwards compatible)
+- **PATCH** version for bug fixes
+
+Examples:
+- `0.1.0` - Initial release
+- `0.1.1` - Bug fix release
+- `0.2.0` - New features added
+- `1.0.0` - Stable API release
+
+## Pre-Release Versions
+
+For alpha/beta releases, append a suffix:
+```bash
+git tag v0.1.0-alpha.1
+git tag v0.1.0-beta.1
+git tag v0.1.0-rc.1
+```
+
+## Troubleshooting
+
+### "Project name already exists"
+If someone else already claimed `ty-find` on PyPI, you'll need to:
+1. Choose a different name (e.g., `ty-find-cli`, `ty-finder`)
+2. Update `pyproject.toml` with the new name
+3. Update the PyPI trusted publisher configuration
+
+### "Authentication failed"
+If PyPI publication fails:
+1. Verify you set up trusted publishing correctly
+2. Check that the workflow name is exactly `release.yml`
+3. Check that the environment name is exactly `pypi`
+4. Ensure the repository owner matches
+
+### "Version already exists"
+If you try to publish the same version twice:
+1. Bump the version in `Cargo.toml`
+2. Create a new tag with the new version
+3. PyPI doesn't allow overwriting versions (this is by design)
+
+### Wheels not building for a platform
+If a specific platform fails:
+1. Check the Actions logs for that platform
+2. Common issues:
+   - Missing system dependencies
+   - Platform-specific Rust compilation errors
+3. You can disable a platform by removing it from the matrix in `release.yml`
+
+## Testing Before Release
+
+Before creating an official release, test the build:
+
+```bash
+# Build locally
+maturin build --release
+
+# Test the wheel
+pip install target/wheels/ty_find-*.whl
+
+# Run tests
+ty-find --help
+ty-find hover test_example.py --line 1 --column 1
+```
+
+## After First Release
+
+Once published to PyPI:
+
+1. Update the README to remove "(coming soon)" from install instructions
+2. Tell users they can now install with: `pip install ty-find`
+3. Consider adding a badge to README:
+   ```markdown
+   [![PyPI version](https://badge.fury.io/py/ty-find.svg)](https://badge.fury.io/py/ty-find)
+   ```
+
+## Continuous Updates
+
+For subsequent releases:
+1. Make your changes
+2. Update `Cargo.toml` version
+3. Create a new git tag
+4. Push the tag
+5. GitHub Actions handles the rest!


### PR DESCRIPTION
- Add GitHub Actions workflow for building wheels on Linux, macOS, Windows
- Add release workflow for automatic PyPI publishing via trusted publishing
- Update README to reflect pre-built wheels will be available
- Add comprehensive publishing guide for maintainers

This eliminates the Rust toolchain requirement for end users once the first release is published to PyPI.