### PR TITLE
Remove Windows from build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-14]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A blazingly fast command-line tool for Python code navigation using ty's LSP ser
 
 ### Quick Install (Recommended)
 
-Pre-built wheels are available for Linux, macOS, and Windows:
+Pre-built wheels are available for Linux and macOS:
 
 ```bash
 # Install from PyPI (coming soon - once first release is published)
@@ -27,6 +27,8 @@ pip install ty-find
 # Or with uv
 uv pip install ty-find
 ```
+
+**Note:** Windows is not currently supported. PRs welcome!
 
 ### For Python Projects
 


### PR DESCRIPTION
Windows is not currently supported. Updated both build.yml and release.yml to remove windows-latest from the build matrix. Added note in README that Windows support is not available (PRs welcome).