### PR TITLE
Update release configuration to use pre-release-commit-message

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -6,9 +6,8 @@ tag = true
 tag-prefix = "v"
 tag-message = "Release {{version}}"
 
-# Create a git commit for the version bump
-commit = true
-commit-message = "Release v{{version}}"
+# Commit message for the version bump
+pre-release-commit-message = "Release v{{version}}"
 
 # Push the commit and tag to the remote
 push = true


### PR DESCRIPTION
## Summary
Updated the release configuration to use the `pre-release-commit-message` option instead of the deprecated `commit` and `commit-message` options.

## Key Changes
- Replaced `commit = true` and `commit-message = "Release v{{version}}"` with `pre-release-commit-message = "Release v{{version}}"`
- Updated the comment to reflect the new configuration option name
- Maintains the same commit message format and release workflow behavior

## Details
This change aligns with the current release tool's configuration schema, replacing the older `commit` boolean flag and separate `commit-message` option with the unified `pre-release-commit-message` configuration. The functionality remains the same—a commit will still be created with the message "Release v{{version}}" during the release process.

https://claude.ai/code/session_017niN4YSN31raLKKE8oRBPt