### PR TITLE
Remove tag-prefix from release configuration

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -3,7 +3,6 @@
 
 # Create a git tag for the release
 tag = true
-tag-prefix = "v"
 tag-message = "Release {{version}}"
 
 # Commit message for the version bump


### PR DESCRIPTION
## Summary
Removed the `tag-prefix = "v"` configuration from the release.toml file. This change allows git tags created during releases to use the default naming convention without the "v" prefix.

## Changes
- Removed the `tag-prefix = "v"` line from release.toml configuration

## Details
This modification simplifies the release tag naming by removing the explicit "v" prefix configuration. Tags will now be created using the version number directly (e.g., "1.0.0" instead of "v1.0.0"), or will follow whatever default behavior is configured in the release tool.

https://claude.ai/code/session_01AmNYqXbV6WY1MgJLLLKuWs