### PR TITLE
Auto-start daemon on first request from CLI commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ mod workspace;
 
 use cli::args::{Cli, Commands, DaemonCommands};
 use cli::output::OutputFormatter;
-use daemon::client::DaemonClient;
+use daemon::client::{ensure_daemon_running, DaemonClient};
 use daemon::server::DaemonServer;
 use lsp::client::TyLspClient;
 use workspace::detection::WorkspaceDetector;
@@ -110,6 +110,7 @@ async fn handle_references_command(
     include_declaration: bool,
     formatter: &OutputFormatter,
 ) -> Result<()> {
+    ensure_daemon_running().await?;
     let mut client = DaemonClient::connect().await?;
 
     let result = client
@@ -256,6 +257,7 @@ async fn handle_hover_command(
     column: u32,
     formatter: &OutputFormatter,
 ) -> Result<()> {
+    ensure_daemon_running().await?;
     let mut client = DaemonClient::connect().await?;
 
     let result = client
@@ -289,6 +291,7 @@ async fn handle_workspace_symbols_command(
     query: &str,
     formatter: &OutputFormatter,
 ) -> Result<()> {
+    ensure_daemon_running().await?;
     let mut client = DaemonClient::connect().await?;
 
     let result = client
@@ -314,6 +317,7 @@ async fn handle_document_symbols_command(
     file: &Path,
     formatter: &OutputFormatter,
 ) -> Result<()> {
+    ensure_daemon_running().await?;
     let mut client = DaemonClient::connect().await?;
 
     let result = client


### PR DESCRIPTION
## Summary
This PR implements automatic daemon startup when daemon-dependent CLI commands are invoked, eliminating the need for users to manually start the daemon beforehand. The daemon is now transparently spawned on-demand when commands like `hover`, `references`, `workspace-symbols`, or `document-symbols` are executed.

## Key Changes

- **Auto-start integration**: Added `ensure_daemon_running()` calls to all daemon-dependent command handlers (`hover`, `references`, `workspace_symbols`, `document_symbols`) to guarantee the daemon is running before attempting to connect.

- **Simplified daemon spawning**: Refactored `spawn_daemon()` to remove the unused `socket_path` parameter and use the `--foreground` flag instead, ensuring the spawned process actually runs the server rather than spawning another process.

- **Improved imports**: Updated `src/main.rs` to import `ensure_daemon_running` from the daemon client module for use in command handlers.

- **Comprehensive test coverage**: Added `test_daemon_auto_start_on_first_request()` integration test that verifies:
  - Daemon is properly cleaned up before the test
  - Running a daemon-dependent command (`hover`) triggers auto-start
  - The daemon socket is created, proving the daemon was spawned
  - Proper cleanup occurs after the test

## Implementation Details

- The daemon spawning uses `Stdio::null()` for stdin/stdout/stderr to fully detach the process from the parent CLI process.
- The `ensure_daemon_running()` function already had polling logic to wait for the daemon socket to appear, so no additional synchronization was needed.
- The test includes a 500ms sleep to allow the daemon time to fully bind the socket, with fallback verification via `daemon status` command.

https://claude.ai/code/session_01CsvtYnJouQQXmwxQLLWLLk