### PR TITLE
Recover source annotations when ty reports Unknown types

### DIFF
--- a/docs/src/commands/members.md
+++ b/docs/src/commands/members.md
@@ -65,10 +65,30 @@ MyClass (src/models.py:15:1)
 
 Line/col references on the right allow jumping to the source.
 
+## Unresolved types
+
+When ty cannot resolve a type — most often because a third-party library's
+stubs are not installed in the analyzed environment — it would normally report
+the type as `Unknown`. Instead of surfacing that, `tyf` substitutes the literal
+type annotation as written in the source file:
+
+```
+Workshop (src/workshop.py:4:1)
+  Methods:
+    build(self) -> pa.Table                                :7:5     # source said `-> pa.Table`
+  Class variables:
+    default_table: pa.Table                                :5:5
+```
+
+This works without the analyzed project's dependencies or stubs installed —
+only the source file is read. If a member genuinely has no annotation in
+source, it is marked `(unannotated)` rather than `Unknown`.
+
 ## Limitations
 
 - Only shows members defined directly on the class, not inherited members (MRO traversal is not yet supported by ty's LSP)
 - Type signatures come from hover, so they require ty to have analyzed the file
+- When a type cannot be resolved, the literal source annotation is shown in place of `Unknown`; `(unannotated)` marks a member with no source annotation
 
 ## See also
 

--- a/docs/src/commands/show.md
+++ b/docs/src/commands/show.md
@@ -65,6 +65,16 @@ tyf show MyClass --all
 tyf inspect MyClass
 ```
 
+## Unresolved types
+
+The `Signature` section reports a symbol's type from ty's analysis. When ty
+cannot resolve a type — typically because a third-party library's stubs are not
+installed — it would normally report `Unknown`. Instead, `tyf` shows the literal
+type annotation as written in source (e.g. `def build(self) -> pa.Table`). Only
+the source file is read, so this works without the project's dependencies
+installed. A symbol with no source annotation is marked `(unannotated)` rather
+than `Unknown`.
+
 ## See also
 
 - [Commands Overview](overview.md)

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,11 @@ The most useful command. Given a symbol name, it shows:
 No file path needed — it searches the whole project by name.
 `inspect` still works as a hidden alias for backward compatibility.
 
+When ty cannot resolve a type (e.g. a third-party library's stubs are not
+installed), the `Signature` shows the literal source annotation the developer
+wrote instead of `Unknown`; a symbol with no annotation is marked
+`(unannotated)`.
+
 ```
 tyf show MyClass
 tyf show MyClass.get_data                # narrow to a specific class method
@@ -67,6 +72,11 @@ Shows the public interface of a class: methods with signatures, properties,
 and class variables with types. Like `list` scoped to a class, with type info.
 Excludes private/dunder members by default; `--all` includes everything.
 Only shows directly-defined members, not inherited ones.
+
+When ty cannot resolve a member's type (e.g. missing third-party stubs), the
+literal source annotation is shown instead of `Unknown` (read from source, so
+it works without the project's dependencies installed); a member with no
+annotation is marked `(unannotated)`.
 
 ```
 tyf members MyClass

--- a/src/annotation.rs
+++ b/src/annotation.rs
@@ -1,0 +1,528 @@
+//! Source-annotation recovery for symbols whose type `ty` reports as `Unknown`.
+//!
+//! `ty` widens a type to `Unknown` when it cannot resolve the annotation —
+//! most often because third-party stubs are not installed in the analyzed
+//! environment (e.g. a method annotated `-> pa.Table` where `pyarrow`'s types
+//! are unresolvable). `Unknown` is technically honest but useless to the
+//! caller, who only needs to know what the developer actually wrote.
+//!
+//! The developer's source annotation is the ground truth. When a rendered type
+//! contains the `Unknown` token, we recover the literal annotation text from
+//! source and show that instead. If the construct genuinely has no annotation,
+//! we show [`UNANNOTATED`] rather than `Unknown` or an empty type.
+//!
+//! This works without the analyzed project's dependencies or stubs installed —
+//! it reads source only. It does not parse imports, inspect lockfiles, or
+//! require a full environment.
+//!
+//! No Python AST crate is available in this project (and adding one would be a
+//! heavy, semver-unstable dependency for a one-symbol lookup), so extraction
+//! uses a small bracket- and quote-aware scanner over the symbol's definition
+//! line. That is enough to handle multi-line signatures, nested brackets,
+//! string annotations, and trailing comments correctly — the cases where naive
+//! line slicing breaks.
+
+/// Marker shown for a symbol that genuinely has no source annotation.
+pub const UNANNOTATED: &str = "(unannotated)";
+
+/// The token `ty` emits for a type it could not resolve.
+const UNKNOWN: &str = "Unknown";
+
+/// Outcome of looking up an annotation in source.
+#[derive(Debug, PartialEq, Eq)]
+enum SourceAnnotation {
+    /// Annotation text recovered from source (already normalized).
+    Found(String),
+    /// The construct exists but has no annotation — caller shows [`UNANNOTATED`].
+    Missing,
+    /// Could not locate or parse the construct — caller keeps the original text.
+    Unparseable,
+}
+
+/// Returns true if `s` contains the bare `Unknown` token, ignoring occurrences
+/// that are part of a longer identifier (e.g. `UnknownError`, `_Unknown`).
+#[must_use]
+pub fn contains_unknown(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut from = 0;
+    while let Some(rel) = s[from..].find(UNKNOWN) {
+        let start = from + rel;
+        let end = start + UNKNOWN.len();
+        let before_ok = start == 0 || !is_ident_byte(bytes[start - 1]);
+        let after_ok = end == bytes.len() || !is_ident_byte(bytes[end]);
+        if before_ok && after_ok {
+            return true;
+        }
+        from = start + 1;
+    }
+    false
+}
+
+const fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
+/// Substitute `Unknown` in a rendered type/signature with the literal source
+/// annotation.
+///
+/// `rendered` is the type text as `ty` produced it (e.g.
+/// `get_table(self) -> Unknown`, `def f() -> Unknown`, or a bare `Unknown` /
+/// `attr: Unknown`). `source` is the full text of the file and `def_line_0` is
+/// the 0-indexed line where the symbol's definition begins.
+///
+/// When the return type (or, for a bare type, the whole type) contains the
+/// `Unknown` token, it is replaced with the source annotation, or with
+/// [`UNANNOTATED`] when source has no annotation. Anything we cannot
+/// confidently recover is left untouched. Inputs without `Unknown` are returned
+/// unchanged.
+#[must_use]
+pub fn substitute_unknown(rendered: &str, source: &str, def_line_0: u32) -> String {
+    if !contains_unknown(rendered) {
+        return rendered.to_string();
+    }
+
+    // Function form: replace the return type when it is the part that is Unknown.
+    if let Some(arrow_end) = top_level_arrow(rendered) {
+        let ret = rendered[arrow_end..].trim();
+        if !contains_unknown(ret) {
+            // The Unknown is in the parameter list, not the return type — the
+            // return-type substitution this performs does not apply. Leave as-is.
+            return rendered.to_string();
+        }
+        let head = rendered[..arrow_end].trim_end();
+        return match return_annotation(source, def_line_0) {
+            SourceAnnotation::Found(ann) => format!("{head} {ann}"),
+            SourceAnnotation::Missing => format!("{head} {UNANNOTATED}"),
+            SourceAnnotation::Unparseable => rendered.to_string(),
+        };
+    }
+
+    // Bare-type form: `attr: Unknown` (members prefixes the name) or just
+    // `Unknown` (hover). Recover the variable/attribute annotation from source.
+    let (prefix, ty) = split_name_prefix(rendered);
+    if !contains_unknown(ty) {
+        return rendered.to_string();
+    }
+    match variable_annotation(source, def_line_0) {
+        SourceAnnotation::Found(ann) => format!("{prefix}{ann}"),
+        SourceAnnotation::Missing => format!("{prefix}{UNANNOTATED}"),
+        SourceAnnotation::Unparseable => rendered.to_string(),
+    }
+}
+
+/// Split a rendered bare type into an optional `name: ` prefix and the type.
+///
+/// `attr: Unknown` → (`"attr: "`, `"Unknown"`). A plain type with no leading
+/// identifier-and-colon (e.g. `dict[str, Unknown]`, `str | None`) yields an
+/// empty prefix and the whole string as the type.
+fn split_name_prefix(rendered: &str) -> (&str, &str) {
+    if let Some(pos) = rendered.find(": ") {
+        let name = &rendered[..pos];
+        if !name.is_empty() && name.bytes().all(is_ident_byte) {
+            return (&rendered[..pos + 2], &rendered[pos + 2..]);
+        }
+    }
+    ("", rendered)
+}
+
+/// Find the return arrow `->` at bracket depth 0 (outside strings) and return
+/// the byte index of the character immediately after it.
+fn top_level_arrow(s: &str) -> Option<usize> {
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut chars = s.char_indices().peekable();
+    while let Some((i, c)) = chars.next() {
+        if let Some(q) = in_str {
+            if c == '\\' {
+                chars.next();
+            } else if c == q {
+                in_str = None;
+            }
+            continue;
+        }
+        match c {
+            '\'' | '"' => in_str = Some(c),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            '-' if depth == 0 => {
+                if matches!(chars.peek(), Some(&(_, '>'))) {
+                    chars.next();
+                    return Some(i + 2);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Recover the literal return annotation from a function definition.
+///
+/// Scans from `def_line_0` (skipping decorators, which have no top-level `->`
+/// or `:`), tracking bracket depth and string state, until the `:` that ends
+/// the `def` header. The annotation is the text between `->` and that colon.
+fn return_annotation(source: &str, def_line_0: u32) -> SourceAnnotation {
+    let Some(start) = line_start_offset(source, def_line_0) else {
+        return SourceAnnotation::Unparseable;
+    };
+    let slice = &source[start..];
+
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut seen_params = false;
+    let mut arrow_end: Option<usize> = None;
+    let mut chars = slice.char_indices().peekable();
+
+    while let Some((i, c)) = chars.next() {
+        if let Some(q) = in_str {
+            if c == '\\' {
+                chars.next();
+            } else if c == q {
+                in_str = None;
+            }
+            continue;
+        }
+        match c {
+            '#' => skip_to_eol(&mut chars),
+            '\'' | '"' => in_str = Some(c),
+            '(' => {
+                depth += 1;
+                seen_params = true;
+            }
+            '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            '-' if depth == 0 => {
+                if matches!(chars.peek(), Some(&(_, '>'))) {
+                    chars.next();
+                    arrow_end = Some(i + 2);
+                }
+            }
+            ':' if depth == 0 && seen_params => {
+                return match arrow_end {
+                    Some(a) => finish(&slice[a..i]),
+                    None => SourceAnnotation::Missing,
+                };
+            }
+            _ => {}
+        }
+    }
+    SourceAnnotation::Unparseable
+}
+
+/// Recover the literal annotation from an annotated assignment / variable.
+///
+/// Reads from `def_line_0` to the first top-level `:` (the annotation colon),
+/// then captures up to a top-level `=` or the end of the logical line.
+fn variable_annotation(source: &str, def_line_0: u32) -> SourceAnnotation {
+    let Some(start) = line_start_offset(source, def_line_0) else {
+        return SourceAnnotation::Unparseable;
+    };
+    let slice = &source[start..];
+
+    let mut depth: i32 = 0;
+    let mut in_str: Option<char> = None;
+    let mut ann_start: Option<usize> = None;
+    let mut chars = slice.char_indices().peekable();
+
+    while let Some((i, c)) = chars.next() {
+        if let Some(q) = in_str {
+            if c == '\\' {
+                chars.next();
+            } else if c == q {
+                in_str = None;
+            }
+            continue;
+        }
+        match c {
+            '#' => skip_to_eol(&mut chars),
+            '\'' | '"' => in_str = Some(c),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ':' if depth == 0 && ann_start.is_none() => {
+                // Ignore the walrus operator `:=`.
+                if matches!(chars.peek(), Some(&(_, '='))) {
+                    chars.next();
+                    continue;
+                }
+                ann_start = Some(i + 1);
+            }
+            '=' if depth == 0 => {
+                if let Some(a) = ann_start {
+                    return finish(&slice[a..i]);
+                }
+            }
+            '\n' if depth == 0 => {
+                return match ann_start {
+                    Some(a) => finish(&slice[a..i]),
+                    None => SourceAnnotation::Missing,
+                };
+            }
+            _ => {}
+        }
+    }
+    match ann_start {
+        Some(a) => finish(&slice[a..]),
+        None => SourceAnnotation::Missing,
+    }
+}
+
+/// Advance the iterator to (but not past) the next newline.
+fn skip_to_eol(chars: &mut std::iter::Peekable<std::str::CharIndices<'_>>) {
+    while let Some(&(_, c)) = chars.peek() {
+        if c == '\n' {
+            break;
+        }
+        chars.next();
+    }
+}
+
+/// Byte offset of the start of 0-indexed `line`, or `None` if out of range.
+fn line_start_offset(source: &str, line: u32) -> Option<usize> {
+    if line == 0 {
+        return Some(0);
+    }
+    let mut seen = 0u32;
+    for (i, b) in source.bytes().enumerate() {
+        if b == b'\n' {
+            seen += 1;
+            if seen == line {
+                return Some(i + 1);
+            }
+        }
+    }
+    None
+}
+
+/// Normalize a raw annotation span into clean type text, classifying empty
+/// spans as [`SourceAnnotation::Missing`].
+fn finish(raw: &str) -> SourceAnnotation {
+    let norm = normalize(raw);
+    if norm.is_empty() {
+        SourceAnnotation::Missing
+    } else {
+        SourceAnnotation::Found(norm)
+    }
+}
+
+/// Collapse whitespace/newlines/comments out of an annotation span and strip a
+/// single enclosing string-literal quote pair (stringized annotation).
+fn normalize(raw: &str) -> String {
+    // Strip any line comments first (the span can cross lines that carry `#`).
+    let mut without_comments = String::with_capacity(raw.len());
+    let mut in_str: Option<char> = None;
+    let mut chars = raw.chars().peekable();
+    while let Some(c) = chars.next() {
+        if let Some(q) = in_str {
+            without_comments.push(c);
+            if c == '\\' {
+                if let Some(n) = chars.next() {
+                    without_comments.push(n);
+                }
+            } else if c == q {
+                in_str = None;
+            }
+            continue;
+        }
+        match c {
+            '#' => {
+                while let Some(&n) = chars.peek() {
+                    if n == '\n' {
+                        break;
+                    }
+                    chars.next();
+                }
+            }
+            '\'' | '"' => {
+                in_str = Some(c);
+                without_comments.push(c);
+            }
+            _ => without_comments.push(c),
+        }
+    }
+
+    // Collapse all whitespace runs to single spaces.
+    let collapsed = without_comments.split_whitespace().collect::<Vec<_>>().join(" ");
+    // Tidy spacing introduced inside brackets by the collapse.
+    let collapsed =
+        collapsed.replace("( ", "(").replace(" )", ")").replace("[ ", "[").replace(" ]", "]");
+    let trimmed = collapsed.trim();
+    strip_enclosing_quotes(trimmed)
+}
+
+/// Strip one enclosing quote pair if the whole string is a single string
+/// literal (e.g. `"pa.Table"` → `pa.Table`).
+fn strip_enclosing_quotes(s: &str) -> String {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' || first == b'\'') && first == last {
+            let inner = &s[1..s.len() - 1];
+            if !inner.contains(first as char) {
+                return inner.trim().to_string();
+            }
+        }
+    }
+    s.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_unknown_matches_bare_token() {
+        assert!(contains_unknown("Unknown"));
+        assert!(contains_unknown("get(self) -> Unknown"));
+        assert!(contains_unknown("dict[str, Unknown]"));
+        assert!(contains_unknown("list[Unknown]"));
+    }
+
+    #[test]
+    fn contains_unknown_ignores_longer_identifiers() {
+        assert!(!contains_unknown("UnknownError"));
+        assert!(!contains_unknown("_Unknown"));
+        assert!(!contains_unknown("MyUnknownType"));
+        assert!(!contains_unknown("str | None"));
+    }
+
+    #[test]
+    fn return_annotation_simple() {
+        let src = "def f(self) -> pa.Table:\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn return_annotation_generic_with_brackets() {
+        let src = "def f(self, x: int) -> dict[str, pa.Table]:\n    ...\n";
+        assert_eq!(
+            return_annotation(src, 0),
+            SourceAnnotation::Found("dict[str, pa.Table]".to_string())
+        );
+    }
+
+    #[test]
+    fn return_annotation_missing() {
+        let src = "def f(self):\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Missing);
+    }
+
+    #[test]
+    fn return_annotation_multiline_signature() {
+        let src = "def assist(\n    self,\n    task: str,\n) -> pa.Table:\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn return_annotation_stringized() {
+        let src = "def f(self) -> \"pa.Table\":\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn return_annotation_trailing_comment() {
+        let src = "def f(self) -> pa.Table:  # returns a table\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn return_annotation_skips_decorators() {
+        let src = "@property\ndef f(self) -> pa.Table:\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn return_annotation_default_with_colon_in_params() {
+        let src = "def f(self, m: dict[str, int] = {}) -> pa.Table:\n    ...\n";
+        assert_eq!(return_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn variable_annotation_simple() {
+        let src = "table: pa.Table = load()\n";
+        assert_eq!(variable_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn variable_annotation_no_default() {
+        let src = "table: pa.Table\n";
+        assert_eq!(variable_annotation(src, 0), SourceAnnotation::Found("pa.Table".to_string()));
+    }
+
+    #[test]
+    fn variable_annotation_missing() {
+        let src = "table = load()\n";
+        assert_eq!(variable_annotation(src, 0), SourceAnnotation::Missing);
+    }
+
+    #[test]
+    fn substitute_return_type_with_source_annotation() {
+        let src = "def get_table(self) -> pa.Table:\n    ...\n";
+        let out = substitute_unknown("get_table(self) -> Unknown", src, 0);
+        assert_eq!(out, "get_table(self) -> pa.Table");
+    }
+
+    #[test]
+    fn substitute_return_type_with_def_prefix() {
+        let src = "def get_table(self) -> pa.Table:\n    ...\n";
+        let out = substitute_unknown("def get_table(self) -> Unknown", src, 0);
+        assert_eq!(out, "def get_table(self) -> pa.Table");
+    }
+
+    #[test]
+    fn substitute_generic_return_type() {
+        let src = "def cols(self) -> list[pa.Field]:\n    ...\n";
+        let out = substitute_unknown("cols(self) -> list[Unknown]", src, 0);
+        assert_eq!(out, "cols(self) -> list[pa.Field]");
+    }
+
+    #[test]
+    fn substitute_unannotated_return() {
+        let src = "def mystery(self):\n    ...\n";
+        let out = substitute_unknown("mystery(self) -> Unknown", src, 0);
+        assert_eq!(out, "mystery(self) -> (unannotated)");
+    }
+
+    #[test]
+    fn substitute_bare_variable_type() {
+        let src = "table: pa.Table = load()\n";
+        let out = substitute_unknown("table: Unknown", src, 0);
+        assert_eq!(out, "table: pa.Table");
+    }
+
+    #[test]
+    fn substitute_leaves_resolvable_types_untouched() {
+        let src = "def speak(self) -> str:\n    ...\n";
+        let out = substitute_unknown("speak(self) -> str", src, 0);
+        assert_eq!(out, "speak(self) -> str");
+    }
+
+    #[test]
+    fn substitute_leaves_param_unknown_untouched() {
+        // Unknown is in a parameter, not the return type — out of scope.
+        let src = "def f(self, x: pa.Table) -> str:\n    ...\n";
+        let out = substitute_unknown("f(self, x: Unknown) -> str", src, 0);
+        assert_eq!(out, "f(self, x: Unknown) -> str");
+    }
+
+    #[test]
+    fn substitute_multiline_signature() {
+        let src = "def assist(\n    self,\n    task: str,\n) -> pa.Table:\n    ...\n";
+        let out = substitute_unknown("assist(self, task: str) -> Unknown", src, 0);
+        assert_eq!(out, "assist(self, task: str) -> pa.Table");
+    }
+
+    #[test]
+    fn substitute_stringized_annotation() {
+        let src = "def f(self) -> \"pa.Table\":\n    ...\n";
+        let out = substitute_unknown("f(self) -> Unknown", src, 0);
+        assert_eq!(out, "f(self) -> pa.Table");
+    }
+
+    #[test]
+    fn substitute_trailing_comment_no_leak() {
+        let src = "def f(self) -> pa.Table:  # not part of the type\n    ...\n";
+        let out = substitute_unknown("f(self) -> Unknown", src, 0);
+        assert_eq!(out, "f(self) -> pa.Table");
+    }
+}

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -88,6 +88,9 @@ pub enum Commands {
         its type signature, and optionally all usages. Searches the whole project by name, \
         no file path needed.\n\n\
         Use Class.method dotted notation to narrow to a specific class member.\n\n\
+        When ty cannot resolve a type (e.g. missing third-party stubs), the signature \
+        shows the literal source annotation instead of 'Unknown'; a symbol with no \
+        annotation is marked '(unannotated)'.\n\n\
         Examples:\n  \
         tyf show MyClass\n  \
         tyf show MyClass.get_data             # narrow to a specific class method\n  \
@@ -207,6 +210,9 @@ pub enum Commands {
         Excludes private (_prefixed) and dunder (__dunder__) members by default; \
         use --all to include everything.\n\n\
         Note: only shows members defined directly on the class, not inherited members.\n\n\
+        When ty cannot resolve a member's type (e.g. missing third-party stubs), the \
+        literal source annotation is shown instead of 'Unknown'; a member with no \
+        annotation is marked '(unannotated)'.\n\n\
         Examples:\n  \
         tyf members MyClass\n  \
         tyf members MyClass UserService        # multiple classes\n  \

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -894,10 +894,31 @@ impl OutputFormatter {
 
         // Non-class or source not readable: use hover type
         if let Some(hover) = hover {
-            output.push_str(&Self::extract_hover_type(&hover.contents));
+            let ty = Self::extract_hover_type(&hover.contents);
+            output.push_str(&Self::resolve_unknown_type(ty, location, cache));
             output.push('\n');
         } else {
             output.push_str(empty_label);
+        }
+    }
+
+    /// Replace a `ty`-reported `Unknown` type with the literal source annotation.
+    ///
+    /// When `ty` cannot resolve an annotation (typically missing third-party
+    /// stubs) it widens the type to `Unknown`, which is useless to the caller.
+    /// If we have the symbol's definition location and its source, recover the
+    /// annotation the developer actually wrote. Types without `Unknown`, or
+    /// where source is unavailable, are returned unchanged.
+    fn resolve_unknown_type(
+        ty: String,
+        location: Option<&Location>,
+        cache: &SourceCache,
+    ) -> String {
+        let Some(loc) = location else { return ty };
+        let abs_path = loc.uri.strip_prefix("file://").unwrap_or(&loc.uri);
+        match cache.get_content(abs_path) {
+            Some(src) => crate::annotation::substitute_unknown(&ty, src, loc.range.start.line),
+            None => ty,
         }
     }
 
@@ -1163,13 +1184,13 @@ impl OutputFormatter {
         }
         match self.format {
             OutputFormat::Human => self.format_show_human(entry, 1, cache),
-            OutputFormat::Json => Self::format_show_json_single(entry),
+            OutputFormat::Json => Self::format_show_json_single(entry, cache),
             OutputFormat::Csv => self.format_show_csv_single(entry, false),
             OutputFormat::Paths => self.format_show_paths_single(entry),
         }
     }
 
-    fn format_show_json_single(entry: &ShowEntry<'_>) -> String {
+    fn format_show_json_single(entry: &ShowEntry<'_>, cache: &SourceCache) -> String {
         let refs_json: Vec<serde_json::Value> =
             entry.displayed_references.iter().map(Self::enriched_ref_to_json).collect();
 
@@ -1182,6 +1203,7 @@ impl OutputFormatter {
 
         let signature = entry.hover.as_ref().and_then(|h| {
             let t = Self::extract_hover_type(&h.contents);
+            let t = Self::resolve_unknown_type(t, entry.definitions.first(), cache);
             if t.is_empty() {
                 None
             } else {
@@ -1297,7 +1319,7 @@ impl OutputFormatter {
                 let grouped: Vec<serde_json::Value> = results
                     .iter()
                     .map(|entry| {
-                        serde_json::from_str(&Self::format_show_json_single(entry))
+                        serde_json::from_str(&Self::format_show_json_single(entry, cache))
                             .unwrap_or_default()
                     })
                     .collect();

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -604,6 +604,14 @@ impl DaemonServer {
             })
             .collect();
 
+        // Read the source once (for the whole class) so we can recover literal
+        // annotations for any member whose type `ty` reports as `Unknown` (e.g.
+        // missing stubs). The CLI-side `show` path reaches the same
+        // `annotation::substitute_unknown` via its `SourceCache`; the daemon has
+        // no such cache, so it reads from disk directly. A single one-shot read
+        // per `members` call is cheap relative to the N hover RPCs above.
+        let source = tokio::fs::read_to_string(&file_str).await.ok();
+
         // Get hover info for each member (N LSP calls — sequential, single pipe)
         let mut members = Vec::with_capacity(filtered.len());
         for child in &filtered {
@@ -611,8 +619,15 @@ impl DaemonServer {
             let hover_col = child.selection_range.start.character;
             let hover = Self::hover_with_warmup(&client, &file_str, hover_line, hover_col).await?;
 
-            let signature =
-                hover.as_ref().map(|h| Self::extract_member_signature(&h.contents, &child.name));
+            let signature = hover.as_ref().map(|h| {
+                let sig = Self::extract_member_signature(&h.contents, &child.name);
+                match source.as_deref() {
+                    Some(src) => {
+                        crate::annotation::substitute_unknown(&sig, src, child.range.start.line)
+                    }
+                    None => sig,
+                }
+            });
 
             members.push(MemberInfo {
                 name: child.name.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+mod annotation;
 mod cli;
 mod commands;
 #[cfg(unix)]

--- a/tests/integration/test_basic.rs
+++ b/tests/integration/test_basic.rs
@@ -488,6 +488,100 @@ async fn test_members_command_csv_format() {
     );
 }
 
+/// Path to the fixture with unresolvable annotations.
+fn unknown_types_fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("unknown_types_example.py")
+}
+
+#[tokio::test]
+async fn test_members_substitutes_unknown_with_source_annotation() {
+    common::require_ty();
+
+    let mut cmd = cargo_bin_cmd!("tyf");
+    cmd.arg("--workspace")
+        .arg(workspace_root())
+        .arg("members")
+        .arg("Workshop")
+        .arg("--all")
+        .arg("--file")
+        .arg(unknown_types_fixture_path());
+
+    let output = cmd.output().expect("failed to run tyf");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "command failed: {stdout}");
+
+    // `ty` cannot resolve `Widget`, so without substitution these would render
+    // as `Unknown`. The literal source annotation must be shown instead. Assert
+    // on the rendered type tokens (`-> Unknown`, `: Unknown`) rather than the
+    // bare word, which can legitimately appear elsewhere (e.g. docstrings).
+    assert!(
+        !predicate::str::contains("-> Unknown").eval(&stdout),
+        "Unknown must not leak into a return type, got:\n{stdout}"
+    );
+    assert!(
+        !predicate::str::contains(": Unknown").eval(&stdout),
+        "Unknown must not leak into a variable type, got:\n{stdout}"
+    );
+
+    // Simple unresolvable return type.
+    assert!(
+        predicate::str::contains("build(self) -> Widget").eval(&stdout),
+        "should substitute return annotation, got:\n{stdout}"
+    );
+    // Generic over the unresolvable type.
+    assert!(
+        predicate::str::contains("build_many(self) -> list[Widget]").eval(&stdout),
+        "should substitute generic return annotation, got:\n{stdout}"
+    );
+    // Multi-line signature: collapsed, with substituted return type.
+    assert!(
+        predicate::str::contains("build_with_options(self, name: str, count: int = 1) -> Widget")
+            .eval(&stdout),
+        "should handle multi-line signature, got:\n{stdout}"
+    );
+    // Stringized annotation: shown without quotes.
+    assert!(
+        predicate::str::contains("build_lazy(self) -> Widget").eval(&stdout),
+        "should show stringized annotation contents, got:\n{stdout}"
+    );
+    // Class variable annotated with the unresolvable type.
+    assert!(
+        predicate::str::contains("default_widget: Widget").eval(&stdout),
+        "should substitute class-variable annotation, got:\n{stdout}"
+    );
+    // Normally-resolvable type is unchanged.
+    assert!(
+        predicate::str::contains("resolved(self) -> str").eval(&stdout),
+        "resolvable type must be unchanged, got:\n{stdout}"
+    );
+}
+
+#[tokio::test]
+async fn test_show_substitutes_unknown_with_source_annotation() {
+    common::require_ty();
+
+    let mut cmd = cargo_bin_cmd!("tyf");
+    cmd.arg("--workspace")
+        .arg(workspace_root())
+        .arg("show")
+        .arg("build")
+        .arg("--file")
+        .arg(unknown_types_fixture_path());
+
+    let output = cmd.output().expect("failed to run tyf");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "command failed: {stdout}");
+
+    assert!(
+        predicate::str::contains("-> Widget").eval(&stdout),
+        "show should surface source annotation, got:\n{stdout}"
+    );
+    assert!(
+        !predicate::str::contains("-> Unknown").eval(&stdout),
+        "Unknown must not leak into show output, got:\n{stdout}"
+    );
+}
+
 // ── Reference count and enrichment tests ───────────────────────────
 
 #[tokio::test]

--- a/unknown_types_example.py
+++ b/unknown_types_example.py
@@ -1,0 +1,41 @@
+"""Test fixture for Unknown-type substitution (members/show).
+
+The import below is deliberately unresolvable, so `ty` cannot resolve the
+annotations that reference `Widget` and widens them to `Unknown`. The CLI must
+substitute the literal source annotation instead. This simulates the real case
+where a third-party library's stubs are not installed in the analyzed
+environment (e.g. `pyarrow`).
+"""
+
+from nonexistent_pkg import Widget  # type: ignore
+
+
+class Workshop:
+    """A class whose annotations reference an unresolvable type."""
+
+    # Class variable annotated with an unresolvable type.
+    default_widget: Widget = make_default()  # noqa: F821
+
+    def build(self) -> Widget:
+        """Return type is unresolvable -> ty reports Unknown."""
+        return Widget()
+
+    def build_many(self) -> list[Widget]:
+        """Generic over an unresolvable type."""
+        return []
+
+    def build_with_options(
+        self,
+        name: str,
+        count: int = 1,
+    ) -> Widget:
+        """Multi-line signature with an unresolvable return type."""
+        return Widget()
+
+    def build_lazy(self) -> "Widget":
+        """Stringized annotation referencing an unresolvable type."""
+        return Widget()
+
+    def resolved(self) -> str:
+        """Normally-resolvable return type — must be unchanged."""
+        return "ok"


### PR DESCRIPTION
## Summary

When `ty` cannot resolve a type annotation (typically due to missing third-party stubs), it widens the type to `Unknown`, which is unhelpful to users. This PR adds source-annotation recovery: when a rendered type contains the `Unknown` token, we extract and display the literal annotation the developer wrote instead.

This works without the analyzed project's dependencies or stubs installed — only the source file is read. If a symbol genuinely has no annotation, it is marked `(unannotated)` rather than `Unknown`.

## Key Changes

- **New module `src/annotation.rs`** (528 lines): Implements annotation recovery from source
  - `contains_unknown()`: Detects bare `Unknown` tokens (ignoring longer identifiers like `UnknownError`)
  - `substitute_unknown()`: Main entry point — replaces `Unknown` in rendered types with source annotations
  - `return_annotation()`: Extracts return type from function definitions (handles multi-line signatures, nested brackets, strings, comments)
  - `variable_annotation()`: Extracts type from annotated assignments (handles walrus operator, defaults, newlines)
  - `normalize()`: Cleans up extracted text (collapses whitespace, strips comments, removes enclosing quotes)
  - Comprehensive test suite (20 tests covering edge cases)

- **CLI integration (`src/cli/output.rs`)**:
  - `resolve_unknown_type()`: New helper that applies substitution when displaying hover types
  - Integrated into `format_show_human()` to replace `Unknown` in show command output

- **Daemon integration (`src/daemon/server.rs`)**:
  - Reads source file once per `members` call (cheap relative to N hover RPCs)
  - Applies substitution to each member's signature before returning

- **Documentation updates**:
  - `docs/src/commands/members.md`: Explains unresolved type handling with example
  - `docs/src/commands/show.md`: Documents the substitution behavior
  - `llms.txt`: Updated project overview with feature description
  - `src/cli/args.rs`: Updated help text for `show` command

- **Test fixture `unknown_types_example.py`**: Demonstrates the feature with an unresolvable `Widget` type across various annotation patterns (simple return, generic, multi-line, stringized, class variable)

- **Integration tests (`tests/integration/test_basic.rs`)**:
  - `test_members_substitutes_unknown_with_source_annotation()`: Verifies `members` command shows source annotations instead of `Unknown`
  - `test_show_substitutes_unknown_with_source_annotation()`: Verifies `show` command surfaces source annotations

## Implementation Details

The annotation extraction uses a bracket- and quote-aware scanner over the symbol's definition line rather than a full Python AST parser (which would be a heavy dependency). This is sufficient to handle:
- Multi-line signatures (collapsed to single line in output)
- Nested brackets and generics
- String-literal annotations (quotes stripped)
- Trailing comments (excluded from annotation)
- Walrus operator (`:=` distinguished from annotation colon)
- Default values with colons in parameter types

The scanner tracks bracket depth and string state to correctly identify top-level syntax elements (`:` for annotations, `->` for return types, `=` for defaults) while ignoring those inside strings or nested brackets.

https://claude.ai/code/session_01QfhZwfhUxqUoegMjGrVAM7