### PR TITLE
Document relationship to ty and add troubleshooting guide

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Setup with Claude Code](setup.md)
 - [How It Works](how-it-works.md)
+- [Relationship to ty](relationship-to-ty.md)
 
 # Commands
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,6 +18,10 @@ LSP servers are the gold standard for code intelligence, but they require file p
 
 tyf breaks this cycle: symbol name in → structured LSP knowledge out. No file paths, no line numbers, no grep step needed.
 
+### vs ty check
+
+tyf surfaces ty's **navigation and symbol** knowledge — definitions, signatures, and references — **not** ty's type-checking diagnostics. So the false-positive noise that affects `ty check` on dynamic frameworks (Pydantic, SQLAlchemy, and similar) never appears in tyf output, because tyf doesn't report type errors at all. See [Relationship to ty](relationship-to-ty.md) for how the two tools relate.
+
 ## Installation
 
 ty-find requires [ty](https://github.com/astral-sh/ty) to be installed and on PATH.

--- a/docs/src/relationship-to-ty.md
+++ b/docs/src/relationship-to-ty.md
@@ -1,0 +1,86 @@
+# Relationship to ty
+
+`tyf` is an **adapter over [ty](https://github.com/astral-sh/ty)'s LSP server**. It does no Python analysis of its own — every definition, signature, and reference it returns comes from `ty`.
+
+## tyf does not ship ty
+
+`ty` is a **required peer dependency that you install yourself**. `tyf` does not bundle, vendor, or pin a copy of `ty`. At runtime it binds to whatever `ty` it finds:
+
+1. `ty` on your `PATH` (preferred), or
+2. `uvx ty` as a fallback.
+
+The analysis you get therefore depends on the `ty` version in your environment, not on the `tyf` version. Upgrading `tyf` does not upgrade `ty`, and upgrading `ty` does not upgrade `tyf`.
+
+```bash
+# Install ty yourself (required)
+uv add --dev ty
+```
+
+## Why this matters: ty is pre-release
+
+`ty` is **pre-release software (`0.0.x`)** under active development, with frequent breaking changes — including to LSP and diagnostic behavior. Because `tyf` binds to your installed `ty` at runtime, a `ty` upgrade can change `tyf`'s output without any change to `tyf` itself.
+
+Practical guidance:
+
+- Keep `ty` current **within the supported range** (see [Supported ty versions](#supported-ty-versions)).
+- If results change after a `ty` upgrade, check your `ty` version against the supported list before assuming a `tyf` bug — see [Which ty am I running, and is it supported?](troubleshooting.md#which-ty-am-i-running-and-is-it-supported).
+
+## What tyf surfaces (and what it doesn't)
+
+`tyf` surfaces `ty`'s **navigation and symbol knowledge** — definitions, type signatures, references, and class members — **not** `ty`'s type-checking diagnostics. `tyf` never reports type errors, so the false-positive noise that affects `ty check` on dynamic frameworks (Pydantic, SQLAlchemy, and similar) does **not** appear in `tyf` output.
+
+## Supported ty versions
+
+<!-- TODO(version-floor): replace this placeholder with a reference to the single
+     source of truth for supported ty versions once the version-floor / CI task
+     lands. Do not hardcode a second copy of the version list here. -->
+
+> **⚠️ Placeholder — pending the version-floor task.**
+> The concrete list of supported `ty` versions is owned by the version-floor / CI
+> task as a **single source of truth**. That source is not in this repository yet,
+> so **no version numbers are listed here** (and none are invented). When the
+> source lands, this section will reference it rather than copy it.
+
+**Support policy.** `tyf` is tested against specific pinned `ty` versions and supports a contiguous range — from a documented floor up to the latest tested release. The exact floor, the latest tested version, and the policy's bound (for example latest-N) are defined by the version-floor task referenced above.
+
+In the meantime, you can always check which `ty` you are running:
+
+```bash
+ty --version
+# or, if ty is only reachable through uv:
+uvx ty --version
+```
+
+## Testing
+
+`tyf`'s integration tests drive a **real `ty lsp` process** — `ty` is never mocked. Each test spawns the actual `tyf` binary, which starts a real daemon and a real `ty` LSP server, then asserts on the structured output for known fixtures.
+
+Fixtures live at the repo root:
+
+| Fixture | Purpose |
+|---------|---------|
+| `example.py` | Minimal single-file fixture used by the basic suite |
+| `test_project/` | Multi-file project exercising classes, generics, protocols, enums, async code, decorators, and exceptions |
+| `test_project2/` | A second workspace, used to test multi-workspace daemon behavior |
+
+The integration suites live in `tests/integration/`: `test_basic.rs`, `test_complex_project.rs`, `test_daemon.rs`, `test_multi_workspace.rs`, and `test_project_smoke.rs`.
+
+### Running the tests locally
+
+`ty` must be installed and on `PATH` (or reachable via `uvx ty`). Tests that need it call `require_ty()` and fail fast with install instructions if it is missing.
+
+```bash
+# Install ty (required for integration tests)
+uv add --dev ty
+
+# Run everything (unit + integration)
+cargo test --all-features
+
+# Run just the basic integration suite
+cargo test --test test_basic
+```
+
+CI runs the same `cargo test --all-features` suite with `ty` installed, plus a separate smoke-test workflow (`benchmarks/smoke.sh`) against the release binary.
+
+<!-- Gated: not yet shipped. -->
+> _Planned (not yet shipped): running the integration suite against each pinned `ty` version in the supported range, driven by the version-floor task's source of truth._

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -49,11 +49,39 @@ The first call in a session is expected to be slower because it:
 
 Subsequent calls reuse the running daemon and typically respond in 50–100ms. If every call is slow, check that the daemon is staying alive between calls with `tyf daemon status`.
 
-## No results for a symbol that exists
+## Empty results for something that should exist
 
-- Verify the symbol is in a `.py` file within the workspace.
-- Check that ty can analyze the file: `ty check file.py`.
-- Some dynamic constructs (e.g., `getattr`, runtime-generated classes) are not visible to static analysis.
+Empty output has two distinct causes — diagnose which one you're hitting before assuming a `tyf` bug.
+
+**(a) The symbol isn't statically visible.** Some dynamic constructs are invisible to static analysis: `getattr`/`setattr` access, runtime-generated classes and methods, attributes assigned through `__init__` magic, and names created by metaprogramming. If the symbol only exists at runtime, `ty` can't see it and neither can `tyf`. First, verify the symbol is in a `.py` file within the workspace.
+
+**(b) `ty` couldn't resolve the environment.** If `ty` is pointed at the wrong interpreter, is missing type stubs, or a third-party package isn't installed, it fails to resolve imports — and unresolved imports cascade into empty navigation results. This looks identical to "not found" but is an environment problem, not a `tyf` problem.
+
+**Diagnostic:** run `ty check` on the file directly:
+
+```bash
+ty check path/to/file.py
+```
+
+If `ty` reports **unresolved imports** (e.g. "Cannot resolve imported module"), it's an environment problem — fix the interpreter/stubs/dependencies, not your `tyf` query. See how `tyf` behaves with third-party packages and `.venv` resolution in [How It Works](how-it-works.md). If imports resolve cleanly but the symbol still doesn't appear, you're in case (a) above.
+
+## Which ty am I running, and is it supported?
+
+Because `tyf` binds at runtime to whatever `ty` is on your `PATH` (or `uvx ty`), the `ty` version determines your results. Print it with:
+
+```bash
+ty --version
+# or, if ty is only reachable through uv:
+uvx ty --version
+```
+
+Compare that against the [Supported ty versions](relationship-to-ty.md#supported-ty-versions) list. `ty` is pre-release (`0.0.x`) and changes often, so if results shift after an upgrade, a version outside the supported range is the first thing to check.
+
+## Signatures show a source annotation or `(unannotated)`
+
+This is expected behavior, not a bug. When `ty` cannot resolve a type — most often because a third-party library's stubs aren't installed — it would normally report `Unknown`. Instead, `tyf` falls back to the literal type annotation as written in the source file (e.g. `-> pa.Table`), reading only the source so it works without the project's dependencies installed. A symbol with no source annotation is shown as `(unannotated)` rather than `Unknown`.
+
+See the "Unresolved types" sections on the [show](commands/show.md#unresolved-types) and [members](commands/members.md#unresolved-types) pages for details.
 
 ## Debug logging
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,6 +9,23 @@ line numbers. A background daemon keeps responses under 100ms.
 
 Also useful for humans who want fast, precise Python navigation from the terminal.
 
+## Relationship to ty
+
+tyf is an adapter over ty's LSP server; it does no Python analysis of its own.
+
+- **tyf does not ship ty.** ty is a required peer dependency you install yourself
+  (`uv add --dev ty`). tyf does not bundle or pin a copy — at runtime it binds to
+  whatever ty is on PATH, falling back to `uvx ty`. The analysis you get depends on
+  the installed ty version, not the tyf version.
+- **ty is pre-release (`0.0.x`)** with frequent breaking changes, including to
+  LSP/diagnostic behavior. A ty upgrade can change tyf output with no change to tyf.
+  Keep ty current within the supported range; if results shift after a ty upgrade,
+  check `ty --version` (or `uvx ty --version`) against the supported list.
+- **Navigation, not diagnostics.** tyf surfaces ty's navigation/symbol knowledge —
+  definitions, signatures, references, members — not ty's type-checking diagnostics.
+  tyf never reports type errors, so the false-positive noise that affects `ty check`
+  on dynamic frameworks (Pydantic, SQLAlchemy, etc.) does not appear in tyf output.
+
 ## Commands
 
 ### show — Definition, type signature, and usages of a symbol by name
@@ -137,7 +154,7 @@ Install [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) to speed up look
 
 ## Installation
 
-Requires [ty](https://github.com/astral-sh/ty) (`uv add --dev ty`).
+Requires [ty](https://github.com/astral-sh/ty) (`uv add --dev ty`) — see Relationship to ty above.
 Optional: [ripgrep](https://github.com/BurntSushi/ripgrep) for faster non-existent symbol lookups.
 
 ```
@@ -145,3 +162,41 @@ pip install ty-find
 # or
 uv add --dev ty-find
 ```
+
+## Supported ty versions
+
+Placeholder — pending the version-floor task. The concrete list of supported ty
+versions is owned by a single source of truth (version-floor / CI task) that is not
+in the repository yet, so no version numbers are listed here (and none are invented).
+Policy: tyf is tested against specific pinned ty versions and supports a contiguous
+range, from a documented floor up to the latest tested release. Until the source
+lands, check your own version with `ty --version` (or `uvx ty --version`).
+
+## Testing
+
+tyf's integration tests drive a real `ty lsp` process (ty is never mocked): each test
+spawns the actual tyf binary, which starts a real daemon and a real ty LSP server, and
+asserts on structured output for fixtures at the repo root (`example.py`,
+`test_project/`, `test_project2/`). Suites live in `tests/integration/`.
+
+```
+uv add --dev ty              # ty required for integration tests
+cargo test --all-features    # unit + integration
+cargo test --test test_basic # just the basic integration suite
+```
+
+CI runs `cargo test --all-features` with ty installed, plus a smoke-test workflow
+(`benchmarks/smoke.sh`) against the release binary.
+
+## Troubleshooting
+
+- **Empty results for something that should exist** has two causes. (a) The symbol
+  isn't statically visible (dynamic constructs: `getattr`, runtime-generated classes,
+  metaprogramming). (b) ty couldn't resolve the environment (wrong interpreter, missing
+  stubs, third-party package not installed). Diagnose with `ty check <file>`: unresolved
+  imports mean an environment problem, not a tyf bug.
+- **Which ty am I running, and is it supported?** Print `ty --version` (or
+  `uvx ty --version`) and compare against the supported list.
+- **Signatures show a source annotation or `(unannotated)`.** Expected, not a bug:
+  when ty can't resolve a type (e.g. missing stubs), tyf falls back to the literal
+  source annotation instead of `Unknown`; no annotation is shown as `(unannotated)`.


### PR DESCRIPTION
## Summary

Add comprehensive documentation explaining tyf's relationship to ty, including how tyf binds to ty at runtime, why ty is a required peer dependency, and how to diagnose common issues. This clarifies the boundary between tyf (navigation/symbols) and ty (type-checking), and provides users with clear troubleshooting steps.

## Changes

- **New doc: `docs/src/relationship-to-ty.md`** — Dedicated guide covering:
  - tyf as an adapter over ty's LSP server (no bundled ty)
  - Runtime binding to installed ty (PATH or `uvx` fallback)
  - Why ty's pre-release status (`0.0.x`) matters for reproducibility
  - What tyf surfaces (navigation/symbols) vs. what it doesn't (type-checking diagnostics)
  - Supported ty versions (placeholder pending version-floor task)
  - Integration test architecture and how to run tests locally

- **Updated `llms.txt`** — Added "Relationship to ty" section summarizing the key points, plus expanded "Supported ty versions", "Testing", and "Troubleshooting" sections with practical guidance

- **Updated `docs/src/index.md`** — Added "vs ty check" subsection clarifying that tyf surfaces navigation knowledge, not type-checking diagnostics, so false positives from dynamic frameworks don't appear in tyf output

- **Updated `docs/src/troubleshooting.md`** — Expanded and reorganized:
  - Renamed "No results for a symbol that exists" to "Empty results for something that should exist" with two-part diagnosis (static visibility vs. environment resolution)
  - Added `ty check` diagnostic command to distinguish environment problems from static analysis limits
  - New section: "Which ty am I running, and is it supported?" with version-checking commands
  - New section: "Signatures show a source annotation or `(unannotated)`" explaining fallback behavior when ty can't resolve types

- **Updated `docs/src/SUMMARY.md`** — Added "Relationship to ty" to the navigation menu

## Notable Details

- All version-floor references are placeholders pending the version-floor / CI task; no hardcoded version numbers are invented
- Troubleshooting sections now guide users to run `ty check` as the diagnostic step to separate environment issues from tyf limitations
- Documentation emphasizes that tyf's output depends on the installed ty version, not the tyf version, which is critical for pre-release software

https://claude.ai/code/session_01KbM6s6Dhci8k4xg94pnF6r