### PR TITLE
Add version badge to docs menu bar synced with Cargo.toml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,6 +40,9 @@ jobs:
           curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.17.0/mdbook-mermaid-v0.17.0-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=bin
           echo "$PWD/bin" >> $GITHUB_PATH
 
+      - name: Sync docs version badge with Cargo.toml
+        run: bash docs/gen-version.sh
+
       - name: Build book
         run: mdbook build docs
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ lint-mermaid:
 docs:
 	@echo "📖 Building documentation..."
 	@if command -v mdbook > /dev/null 2>&1; then \
+		bash docs/gen-version.sh; \
 		mdbook build docs; \
 		bash docs/generate-llms-txt.sh; \
 		echo "Docs built at docs/book/html/index.html"; \

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -15,7 +15,7 @@ edit-url-template = "https://github.com/mojzis/ty-find/edit/main/docs/{path}"
 default-theme = "navy"
 preferred-dark-theme = "navy"
 additional-css = ["custom.css"]
-additional-js = ["mermaid.min.js", "mermaid-init.js"]
+additional-js = ["mermaid.min.js", "mermaid-init.js", "version.js"]
 
 [preprocessor]
 

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -223,6 +223,17 @@ html #mdbook-menu-bar {
   border-bottom: 1px solid rgba(128, 128, 128, 0.15) !important;
 }
 
+/* Version badge beside the title — small, dimmed */
+html .menu-title .version-badge {
+  font-size: 0.62em;
+  font-weight: 400;
+  opacity: 0.55;
+  margin-left: 0.5em;
+  letter-spacing: 0.02em;
+  vertical-align: middle;
+  font-variant-numeric: tabular-nums;
+}
+
 html #mdbook-menu-bar .icon-button {
   transition: color 0.15s ease;
 }

--- a/docs/gen-version.sh
+++ b/docs/gen-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Syncs the version badge shown in the docs menu bar with the crate version.
+#
+# Reads the version from Cargo.toml (the single source of truth) and rewrites
+# the VERSION constant in docs/version.js. Run automatically by the docs deploy
+# workflow before `mdbook build`, so the published site always matches Cargo.toml.
+#
+# Usage:
+#   ./docs/gen-version.sh          # update docs/version.js
+#   ./docs/gen-version.sh --check  # exit 1 if docs/version.js is stale
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="$SCRIPT_DIR/version.js"
+
+VERSION=$(grep -m1 '^version' "$REPO_ROOT/Cargo.toml" | sed -E 's/^version *= *"([^"]+)".*/\1/')
+if [[ -z "$VERSION" ]]; then
+    echo "ERROR: could not read version from $REPO_ROOT/Cargo.toml" >&2
+    exit 1
+fi
+
+if [[ "${1:-}" == "--check" ]]; then
+    if grep -qF "var VERSION = \"$VERSION\";" "$TARGET"; then
+        echo "OK: docs version badge is v$VERSION"
+        exit 0
+    fi
+    echo "STALE: $TARGET (run ./docs/gen-version.sh to update to v$VERSION)" >&2
+    exit 1
+fi
+
+sed -i.bak -E "s/(var VERSION = \")[^\"]*(\";)/\1${VERSION}\2/" "$TARGET"
+rm -f "$TARGET.bak"
+echo "Set docs version badge to v$VERSION"

--- a/docs/version.js
+++ b/docs/version.js
@@ -1,0 +1,24 @@
+// Displays the current package version next to the title in the top menu bar.
+// The VERSION constant below is the single line updated by docs/gen-version.sh
+// (run automatically in the docs deploy workflow) and on each `cargo release`.
+(function () {
+  "use strict";
+  var VERSION = "0.4.1";
+
+  function injectVersion() {
+    var title = document.querySelector(".menu-title");
+    if (!title || title.querySelector(".version-badge")) {
+      return;
+    }
+    var badge = document.createElement("span");
+    badge.className = "version-badge";
+    badge.textContent = "v" + VERSION;
+    title.appendChild(badge);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", injectVersion);
+  } else {
+    injectVersion();
+  }
+})();

--- a/release.toml
+++ b/release.toml
@@ -16,3 +16,10 @@ publish = false
 
 # Run pre-release checks
 verify = true
+
+# Keep the version badge shown in the docs menu bar in sync with the crate version
+[[pre-release-replacements]]
+file = "docs/version.js"
+search = 'var VERSION = "[^"]*";'
+replace = 'var VERSION = "{{version}}";'
+exactly = 1


### PR DESCRIPTION
## Summary
Adds a version badge to the documentation menu bar that displays the current crate version. The badge is automatically kept in sync with `Cargo.toml` via a new `docs/gen-version.sh` script that runs during the docs build workflow and on each `cargo release`.

## Key Changes
- **New script `docs/gen-version.sh`**: Reads version from `Cargo.toml` and updates the `VERSION` constant in `docs/version.js`. Supports `--check` mode for CI validation.
- **New file `docs/version.js`**: JavaScript module that injects a styled version badge next to the documentation title on page load.
- **Updated `docs/custom.css`**: Added styling for `.version-badge` (small, dimmed text with proper spacing and typography).
- **Updated `docs/book.toml`**: Added `version.js` to the `additional-js` list so it loads with the documentation.
- **Updated `.github/workflows/docs.yml`**: Added step to run `docs/gen-version.sh` before `mdbook build` to ensure the published docs always match the current version.
- **Updated `Makefile`**: Added `docs/gen-version.sh` call to the `docs` target for local builds.
- **Updated `release.toml`**: Added pre-release replacement rule to automatically update `docs/version.js` during `cargo release`.

## Implementation Details
- The version badge is injected via JavaScript to avoid manual updates and ensure it's always current.
- The script uses `sed` with a backup file for safe in-place editing and validates the version was successfully read from `Cargo.toml`.
- The badge is styled to be unobtrusive (62% font size, 55% opacity) while remaining readable.
- The `--check` mode allows CI to verify the docs version matches the crate version without modifying files.

https://claude.ai/code/session_012BhzV7WwEZ1Pe9MUg8i437